### PR TITLE
Patch retrieve_work method than a subclass can support all sidekiq fetch classes

### DIFF
--- a/lib/sidekiq-rate-limiter.rb
+++ b/lib/sidekiq-rate-limiter.rb
@@ -1,2 +1,2 @@
 require 'sidekiq-rate-limiter/version'
-require 'sidekiq-rate-limiter/fetch'
+require 'sidekiq-rate-limiter/fetch_patch'

--- a/lib/sidekiq-rate-limiter/server.rb
+++ b/lib/sidekiq-rate-limiter/server.rb
@@ -1,6 +1,10 @@
 require 'sidekiq-rate-limiter/version'
-require 'sidekiq-rate-limiter/fetch'
+require 'sidekiq-rate-limiter/fetch_patch'
+require 'sidekiq/fetch'
 
 Sidekiq.configure_server do |config|
-  Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
+  Sidekiq.options[:fetch] ||= Sidekiq::BasicFetch
+  config.on(:startup) do
+    Sidekiq.options[:fetch].class_eval { prepend Sidekiq::RateLimiter::FetchPatch }
+  end
 end

--- a/spec/sidekiq-rate-limiter/server_spec.rb
+++ b/spec/sidekiq-rate-limiter/server_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'sidekiq/util'
+require 'support/job'
 
 RSpec.describe Sidekiq::RateLimiter, 'server configuration' do
   before do
@@ -6,15 +8,20 @@ RSpec.describe Sidekiq::RateLimiter, 'server configuration' do
     require 'sidekiq-rate-limiter/server'
   end
 
-  it 'should set Sidekiq.options[:fetch] as desired' do
+  it 'should set Sidekiq.options[:fetch] to Sidekiq::BasicFetch if blank' do
     Sidekiq.configure_server do |config|
-      expect(Sidekiq.options[:fetch]).to eql(Sidekiq::RateLimiter::Fetch)
+      expect(Sidekiq.options[:fetch]).to eql(Sidekiq::BasicFetch)
     end
   end
 
-  it 'should inherit from Sidekiq::BasicFetch' do
+  it 'should patch the retrieve_work method' do
+    Class.new.extend(Sidekiq::Util).fire_event(:startup)
+    Job.perform_async([])
+    patched_fetch_class = nil
     Sidekiq.configure_server do |config|
-      expect(Sidekiq.options[:fetch]).to be < Sidekiq::BasicFetch
+      patched_fetch_class = Sidekiq.options[:fetch]
     end
+    expect(Sidekiq::RateLimiter).to receive(:limit)
+    patched_fetch_class.new(queues: [:basic]).retrieve_work
   end
 end

--- a/spec/support/job.rb
+++ b/spec/support/job.rb
@@ -1,0 +1,12 @@
+require 'sidekiq'
+
+class Job
+  include Sidekiq::Worker
+  sidekiq_options 'queue' => 'basic',
+                  'retry' => false,
+                  'rate'  => {
+                      'limit'  => 1,
+                      'period' => 1
+                  }
+  def perform(*args); end
+end

--- a/spec/support/proc_job.rb
+++ b/spec/support/proc_job.rb
@@ -1,0 +1,13 @@
+require 'sidekiq'
+
+class ProcJob
+  include Sidekiq::Worker
+  sidekiq_options 'queue' => 'basic',
+                  'retry' => false,
+                  'rate'  => {
+                      'limit'  => ->(arg1, arg2) { arg2 },
+                      'name'   => ->(arg1, arg2) { arg2 },
+                      'period' => ->(arg1, arg2) { arg2 }
+                  }
+  def perform(arg1, arg2); end
+end


### PR DESCRIPTION
Patch retrieve_work method of the user chosen fetch class or the default BasicFetch, so it supports different sidekiq fetch classes